### PR TITLE
perf: allow disable verbose and progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 env
 dist
+*.pyc


### PR DESCRIPTION
Thank you very much for creating the Python package, which will save me a lot of time in reproducing the GAIN method for my research experiments. I have added two options to it so that users can disable the parameter information and progress bar output generated by Imputer when using it. I believe this will improve user experience to some extent.

In addition, I know that inputting arrays using numpy is very common, but have you considered also supporting the input of pandas DataFrames? The related Imputer library in scikit-learn supports pandas. Achieving some level of consistency from this perspective may make your package more user-friendly! After all, in the fields of machine learning and data processing, everyone often uses pandas to organize data.